### PR TITLE
Add debian 11 as supported system

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,15 +14,14 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04",
         "18.04",
         "20.04"


### PR DESCRIPTION
Add Debian 11 as supported OS. Debian 8 is EOL, same for Ubuntu 14.04.